### PR TITLE
Update phpdoc for parseKey

### DIFF
--- a/src/JWK.php
+++ b/src/JWK.php
@@ -62,7 +62,7 @@ class JWK
     /**
      * Parse a JWK key
      * @param $source
-     * @return OpenSSLAsymmetricKey|resource an associative array represents the key
+     * @return OpenSSLAsymmetricKey|resource The public key
      */
     public static function parseKey($source)
     {

--- a/src/JWK.php
+++ b/src/JWK.php
@@ -62,7 +62,7 @@ class JWK
     /**
      * Parse a JWK key
      * @param $source
-     * @return resource|array an associative array represents the key
+     * @return OpenSSLAsymmetricKey|resource an associative array represents the key
      */
     public static function parseKey($source)
     {


### PR DESCRIPTION
The return value for https://www.php.net/manual/en/function.openssl-pkey-get-public.php has changed in PHP 8.